### PR TITLE
HPCC-34913 Create a tool to effectively manage DNS record sets in Azure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignored configuration files
+./godji/azure-dns-record-set-delete/config.sh

--- a/godji/azure-dns-record-set-delete/README.md
+++ b/godji/azure-dns-record-set-delete/README.md
@@ -1,0 +1,27 @@
+# Azure DNS Record Set Delete
+This script deletes specific DNS record sets from Azure based on a keyword. It is a valuable tool for managing DNS resources in Azure.
+
+## Usage
+* Modify config.sh to include the correct arguments.
+* Run main.sh: `./run.sh`
+
+## Config.sh
+
+```
+    #!/bin/bash
+
+    #Get the subscription name
+    SUBSCRIPTION_NAME=""
+
+    # Get the resource group name and zone name from the user.
+    RESOURCE_GROUP_NAME=""
+    DNS_ZONE_NAME=""
+
+    # Get the keyword to select the dns record sets.
+    # This should be common string in all the record names you want to delete.
+    # Examples: hpcc, hpcc2, play
+    KEYWORD=""
+
+    # Types of DNS record sets
+    RECORD_TYPES=("A" "TXT")
+```

--- a/godji/azure-dns-record-set-delete/config.sh
+++ b/godji/azure-dns-record-set-delete/config.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#Get the subscription name
+SUBSCRIPTION_NAME="us-lnhpccplatform-dev"
+
+# Get the resource group name and zone name from the user.
+RESOURCE_GROUP_NAME="app-dns-prod-eastus2"
+DNS_ZONE_NAME="us-lnhpccplatform-dev.azure.lnrsg.io"
+
+# Get the keyword to select the dns record sets.
+# This should be the common string in all of the record names you want to delete.
+# Examples: hpcc, hpcc2, play
+KEYWORD="hpcc2"
+
+# Types of DNS record sets
+RECORD_TYPES=("a" "txt")

--- a/godji/azure-dns-record-set-delete/run.sh
+++ b/godji/azure-dns-record-set-delete/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#Include config.sh
+source ./config.sh
+
+# #Get the subscription name
+# echo "Enter the subscription name:"
+# read SUBSCRIPTION_NAME
+
+# # Get the resource group name and zone name from the user.
+# echo "Enter the resource group name:"
+# read RESOURCE_GROUP_NAME
+# echo "Enter the zone name:"
+# read DNS_ZONE_NAME
+
+# # Get the keyword to select the dns record sets.
+# # This should be common string in all the record names you want to delete.
+# # Examples: hpcc, hpcc2, play
+# echo "Enter the keyword to select a specific record set:"
+# read KEYWORD
+
+# # Types of DNS record sets
+# RECORD_TYPES=("A" "TXT")
+
+# Set the subscription
+az account set --name $SUBSCRIPTION_NAME
+
+# Initialize the array
+RECORD_SETS=()
+
+# Find the records that end with the exact keyword
+find-records () {
+    # Use process substitution to capture the output of the pipeline and set the RECORD_SETS array.
+    while IFS= read -r record; do
+        RECORD_SETS+=("$record")
+    done < <(az network dns record-set list \
+        --resource-group "$RESOURCE_GROUP_NAME" \
+        --zone-name "$DNS_ZONE_NAME" | grep -o '"name": "[^"]*"' | \
+        grep -w "${KEYWORD}" | \
+        awk -F'"' '{print $4}')
+}
+
+# Delete the record sets
+delete-records () {
+    if [ ${#RECORD_SETS[*]} -gt 0 ];then
+        echo "The following list of records will be deleted:"
+        echo ${RECORD_SETS[*]}
+        echo "Are you sure you want to perform this operation? (y/n):"
+        read confirm
+    else
+        echo "No records found."
+        abort
+    fi
+    
+    if [ ${#RECORD_SETS[*]} -gt 0 ] && [ $confirm == 'y' ];then
+        for type in "${RECORD_TYPES[@]}"; do
+        # Delete the record sets.
+            for record_set in "${RECORD_SETS[@]}"; do
+                echo "az network dns record-set $type delete \
+                    --name "$record_set" \
+                    --zone-name "$DNS_ZONE_NAME" \
+                    --resource-group "$RESOURCE_GROUP_NAME""
+
+                az network dns record-set $type delete \
+                    --name "$record_set" \
+                    --zone-name "$DNS_ZONE_NAME" \
+                    --resource-group "$RESOURCE_GROUP_NAME" \
+                    --yes
+            done
+        done
+
+        deleted
+    fi
+}
+
+# Print a success message.
+deleted () {
+    echo "Successfully deleted the DNS record sets."
+}
+
+# Print an abort message
+abort () {
+    echo "The operation has been aborted."
+}
+
+# Call the functions
+find-records
+delete-records


### PR DESCRIPTION
This tool deletes leftover DNS record sets in Azure. If a cluster get manually deleted DNS records will persists because they are in a separate resource group with records from other clusters. This tool only deletes records created by a specific cluster.

https://hpccsystems.atlassian.net/browse/HPCC-34913